### PR TITLE
LIBCIR-39. Speedup MD-SOAR development cycle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then, from the `mdsoar-vagrant` directory:
 $ vagrant up
 $ vagrant ssh
 
-vagrant@localhost$ cd /apps/mdsoar/src/dspace/target/dspace-installer
+vagrant@localhost$ cd /apps/mdsoar/dspace-installer
 vagrant@localhost$ ant fresh_install
 vagrant@localhost$ /apps/mdsoar/bin/dspace create-administrator
 
@@ -64,6 +64,6 @@ You should now have a running DSpace/MD-SOAR installation at
 ## Redeploying
 
 There is a convenience script, [deploy.sh](deploy.sh), that you can use to run
-the ant `fresh_install` target and restart Tomcat. Note that it does not build
+the `ant update_local` target and restart Tomcat. Note that it does not build
 the application (you still need to do that yourself on the host using Maven),
 nor does it create the administrator account.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,8 +19,8 @@ Vagrant.configure(2) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "/apps/git/mdsoar-env", "/apps/mdsoar"
-  config.vm.synced_folder "/apps/git/mdsoar", "/apps/mdsoar/src"
+  config.vm.synced_folder "/apps/git/mdsoar-env", "/apps/mdsoar/mdsoar-env"
+  config.vm.synced_folder "/apps/git/mdsoar/dspace/target/dspace-installer", "/apps/mdsoar/dspace-installer"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,6 +19,10 @@ export JAVA_HOME=$JAVA_HOME
 export PATH=\$JAVA_HOME/bin:/apps/ant/bin:\$PATH
 END
 
+# Make a local copy of env to avoid syncing files deployed by ant
+cp -r /apps/mdsoar/mdsoar-env/* /apps/mdsoar/
+chown -R vagrant:vagrant /apps
+
 # Maven
 # not needed on vagrant guest?
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # deploy DSpace
-cd /apps/mdsoar/src/dspace/target/dspace-installer
-ant fresh_install
+cd /apps/mdsoar/dspace-installer
+ant update_local
 
 cd /apps/mdsoar/tomcat
 ./control restart


### PR DESCRIPTION
Host to Guest Sync updates:
- Sync only /apps/git/mdsoar/dspace/target/dspace-installer instead of /apps/git/mdsoar/
- Made /apps/git/mdsoar-env sync location different from actual ant deploy location to avoid syncing back the deployment files back to host.

Updated (re)deploy shortcut script to do updates instead of fresh install.

https://issues.umd.edu/browse/LIBCIR-39
