### PR TITLE
LIBCIR-85. Vagrant improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 dist/*.tar.gz
+dump.tar.*

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ vagrant@localhost$ /apps/mdsoar/bin/dspace create-administrator
 # Add mdsoar solr cores
 vagrant@localhost$ /vagrant/scripts/mdsoar-solr-cores.sh
 
+# Restore database dump
+# first place a production dump.tar.0 file in /vagrant, then run
+vagrant@localhost$ sudo pg_restore --clean --verbose -d dspace /vagrant/dump.tar.0
+
+# Start Tomcat
 vagrant@localhost$ cd /apps/mdsoar/tomcat
 vagrant@localhost$ ./control start
 

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -19,6 +19,10 @@ postgresql::server::pg_hba_rule { 'dspace access':
     auth_method => 'md5',
     order       => '001',
 }
+# ensure there is a "root" superuser, for compatability with production db dumps
+postgresql::server::role { 'root':
+    superuser => true,
+}
 
 file { "/apps/mdsoar":
     ensure => 'directory',

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -40,7 +40,7 @@ file { "/apps/mdsoar/tomcat/logs":
 # by default the CentOS 6.6 iptables config has
 # all ports closed except for SSH (22)
 firewall { '100 allow http and https access':
-    port   => [80, 443, 8080, 8443, 8983],
+    dport   => [80, 443, 8080, 8443, 8983],
     proto  => tcp,
     action => accept,
 }


### PR DESCRIPTION
- added `root` superuser for Postgres
- added instructions to README for restoring a database dump
- changed deprecated `port` setting to `dport` in the puppet firewall config

https://issues.umd.edu/browse/LIBCIR-85
