### PR TITLE
LIBCIR-71. Install ImageMagick and Ghostscript packages.

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -24,6 +24,14 @@ postgresql::server::role { 'root':
     superuser => true,
 }
 
+# required packages to generate thumbnails (LIBCIR-71)
+package { "ghostscript":
+    ensure => present,
+}
+package { "ImageMagick":
+    ensure => present,
+}
+
 file { "/apps/mdsoar":
     ensure => 'directory',
     owner  => 'vagrant',


### PR DESCRIPTION
These packages are required for the PDF thumbnailer to function.

https://issues.umd.edu/browse/LIBCIR-71
