### PR TITLE
LIBCIR-176. Update mdsoar vagrant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ vagrant@localhost$ /apps/mdsoar/bin/dspace create-administrator
 vagrant@localhost$ /vagrant/scripts/mdsoar-solr-cores.sh
 
 # Restore database dump
-# first place a production dump.tar.0 file in /vagrant, then run
-vagrant@localhost$ sudo pg_restore --clean --verbose -d dspace /vagrant/dump.tar.0
+# first place a production dump.tar.0 file in /vagrant, then run (enter dspace as password when prompted)
+vagrant@localhost$ sudo pg_restore -h 127.0.0.1 -U dspace -W --clean --verbose -d dspace /vagrant/dump.tar.0
 
 # Start Tomcat
 vagrant@localhost$ cd /apps/mdsoar/tomcat

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure(2) do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "puppetlabs/centos-6.6-64-puppet"
+  config.vm.box = "puppetlabs/centos-7.2-64-puppet"
 
   # Set Box Version for puppet
   config.vm.box_version = "1.0.1"
@@ -44,5 +44,5 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "shell", path: 'scripts/bootstrap.sh'
   config.vm.provision "shell", path: 'scripts/update-solr-env.sh'
-  config.vm.provision "puppet"
+  config.vm.provision "shell", inline: 'puppet apply /vagrant/manifests/default.pp'
 end

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -8,6 +8,7 @@ class { 'postgresql::server': }
 # https://wiki.duraspace.org/display/DSDOC5x/Installing+DSpace
 postgresql::server::db { 'dspace':
     user     => 'dspace',
+    owner     => 'dspace',
     password => postgresql_password('dspace', 'dspace'),
     encoding => 'UNICODE',
 }

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -53,3 +53,13 @@ firewall { '100 allow http and https access':
     proto  => tcp,
     action => accept,
 }
+
+# Install Git
+include git
+
+# Ensure that the correct branch of solr-env is checked out
+vcsrepo { '/apps/solr-env-sync':
+  ensure   => present,
+  provider => git,
+  revision => 'local',
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -70,4 +70,4 @@ chown -R vagrant:vagrant /apps/apache-tomcat-${TOMCAT_VERSION}
 
 # Puppet Modules
 puppet module install puppetlabs-firewall
-puppet module install puppetlabs-postgresql
+puppet module install puppetlabs-postgresql --version 4.9.0

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -69,5 +69,7 @@ tar xvzf "$TOMCAT" --directory /apps
 chown -R vagrant:vagrant /apps/apache-tomcat-${TOMCAT_VERSION}
 
 # Puppet Modules
-puppet module install puppetlabs-firewall
+puppet module install puppetlabs-firewall --version 1.9.0
 puppet module install puppetlabs-postgresql --version 4.9.0
+puppet module install puppetlabs-git --version 0.5.0
+puppet module install puppetlabs-vcsrepo --version 1.5.0


### PR DESCRIPTION
Fixed problems that were preventing the mdsoar-vagrant to work the latest versions of vagrant & puppet.
Updated puppet manifest to set correct owner for the dspace database and to ensure the correct git branch is checked out in solr-env repository.

https://issues.umd.edu/browse/LIBCIR-176